### PR TITLE
Secure formulario access and uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,17 @@
+import os
 from flask import Flask
 from routes.main_routes import main
 from routes.formulario_routes import formulario_bp
 
+ENVIRONMENT = os.getenv("FLASK_ENV", os.getenv("ENV", "development")).lower()
+IS_PRODUCTION = ENVIRONMENT == "production"
+
+secret_key = os.getenv("SECRET_KEY")
+if IS_PRODUCTION and not secret_key:
+    raise RuntimeError("SECRET_KEY debe estar configurada en el entorno de producción.")
+
 app = Flask(__name__)
-app.secret_key = "supersecret"  # Necesario para mensajes flash
+app.secret_key = secret_key or "development-secret-key"  # Necesario para mensajes flash
 
 # Registrar rutas
 app.register_blueprint(main)
@@ -13,4 +21,4 @@ if __name__ == '__main__':
     # Ya no verificamos ni cargamos datos en SQLite,
     # porque toda la información se procesa directamente desde Excel
     print("Aplicación iniciada. Usando Excel como fuente principal de datos.")
-    app.run(debug=True, use_reloader=False)
+    app.run(debug=not IS_PRODUCTION, use_reloader=False)

--- a/controllers/formulario_controller.py
+++ b/controllers/formulario_controller.py
@@ -1,7 +1,9 @@
 import os
 import threading
+from uuid import uuid4
 import pandas as pd
-from flask import render_template, request, jsonify, send_file
+from flask import render_template, request, jsonify, send_file, session
+from werkzeug.utils import secure_filename
 from utils.generar_kardex import generar_kardex_consolidado
 from utils.generar_remision import generar_remision_consolidado
 
@@ -10,64 +12,154 @@ UPLOAD_DIR = os.path.join("data", "uploads")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
-# Variables de progreso separadas
-progreso_kardex = {"procesadas": 0, "total": 0, "completado": False, "pdf_final": ""}
-progreso_remision = {"procesadas": 0, "total": 0, "completado": False, "pdf_final": ""}
+DEFAULT_PROGRESS = {"procesadas": 0, "total": 0, "completado": False, "pdf_final": ""}
+ALLOWED_EXTENSIONS = {"xls", "xlsx"}
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10 MB
 
-archivo_cargado = {"ruta": ""}  # Excel cargado solo una vez
+progreso_kardex = {}
+progreso_remision = {}
+archivo_cargado = {}
+
+
+def _get_session_id():
+    if "session_id" not in session:
+        session["session_id"] = uuid4().hex
+    return session["session_id"]
+
+
+def _get_progress(store, session_id):
+    if session_id not in store:
+        store[session_id] = DEFAULT_PROGRESS.copy()
+    return store[session_id]
+
+
+def _get_upload_dir(session_id):
+    carpeta = os.path.join(UPLOAD_DIR, session_id)
+    os.makedirs(carpeta, exist_ok=True)
+    return carpeta
+
+
+def _get_output_dir(session_id):
+    carpeta = os.path.join(OUTPUT_DIR, session_id)
+    os.makedirs(carpeta, exist_ok=True)
+    return carpeta
+
+
+def _get_uploaded_file(session_id):
+    return archivo_cargado.get(session_id)
+
+
+def _validate_file(archivo):
+    filename = secure_filename(archivo.filename or "")
+    if not filename:
+        return False, "Nombre de archivo inválido."
+
+    if "." not in filename or filename.rsplit(".", 1)[1].lower() not in ALLOWED_EXTENSIONS:
+        return False, "Extensión de archivo no permitida. Solo se aceptan .xls o .xlsx."
+
+    archivo.stream.seek(0, os.SEEK_END)
+    size = archivo.stream.tell()
+    archivo.stream.seek(0)
+    if size > MAX_UPLOAD_SIZE:
+        return False, "El archivo excede el tamaño máximo permitido de 10 MB."
+
+    return True, filename
+
 
 def formulario():
+    session_id = _get_session_id()
+    progreso_actual_kardex = _get_progress(progreso_kardex, session_id)
+    progreso_actual_remision = _get_progress(progreso_remision, session_id)
     return render_template("formulario.html",
-                           progreso_kardex=progreso_kardex,
-                           progreso_remision=progreso_remision)
+                           progreso_kardex=progreso_actual_kardex,
+                           progreso_remision=progreso_actual_remision)
+
 
 def cargar_archivo():
     archivo = request.files.get('archivo_excel')
     if not archivo:
         return jsonify({"error": "No se seleccionó archivo"}), 400
-    ruta = os.path.join(UPLOAD_DIR, archivo.filename)
+
+    valido, filename = _validate_file(archivo)
+    if not valido:
+        return jsonify({"error": filename}), 400
+
+    session_id = _get_session_id()
+    carpeta_sesion = _get_upload_dir(session_id)
+    extension = filename.rsplit(".", 1)[1].lower()
+    nombre_final = f"{uuid4().hex}.{extension}"
+    ruta = os.path.join(carpeta_sesion, nombre_final)
+
     archivo.save(ruta)
-    archivo_cargado["ruta"] = ruta
+    archivo_cargado[session_id] = ruta
+    progreso_kardex[session_id] = DEFAULT_PROGRESS.copy()
+    progreso_remision[session_id] = DEFAULT_PROGRESS.copy()
     return jsonify({"status": "cargado"})
 
-def iniciar_kardex():
-    global progreso_kardex
-    if not archivo_cargado["ruta"]:
-        return
-    df = pd.read_excel(archivo_cargado["ruta"])
-    progreso_kardex.update({"total": len(df), "procesadas": 0, "completado": False, "pdf_final": ""})
-    pdf, excels = generar_kardex_consolidado(df, progreso_kardex, OUTPUT_DIR)
-    progreso_kardex.update({"pdf_final": pdf, "completado": True})
 
-def iniciar_remision():
-    global progreso_remision
-    if not archivo_cargado["ruta"]:
+def iniciar_kardex(session_id, ruta_archivo, carpeta_salida):
+    progreso_actual = _get_progress(progreso_kardex, session_id)
+    if not ruta_archivo:
+        progreso_actual.update({"completado": False})
         return
-    df = pd.read_excel(archivo_cargado["ruta"])
-    progreso_remision.update({"total": len(df), "procesadas": 0, "completado": False, "pdf_final": ""})
-    pdf, excels = generar_remision_consolidado(df, progreso_remision, OUTPUT_DIR)
-    progreso_remision.update({"pdf_final": pdf, "completado": True})
+    df = pd.read_excel(ruta_archivo)
+    progreso_actual.update({"total": len(df), "procesadas": 0, "completado": False, "pdf_final": ""})
+    pdf, _ = generar_kardex_consolidado(df, progreso_actual, carpeta_salida)
+    progreso_actual.update({"pdf_final": pdf, "completado": True})
+
+
+def iniciar_remision(session_id, ruta_archivo, carpeta_salida):
+    progreso_actual = _get_progress(progreso_remision, session_id)
+    if not ruta_archivo:
+        progreso_actual.update({"completado": False})
+        return
+    df = pd.read_excel(ruta_archivo)
+    progreso_actual.update({"total": len(df), "procesadas": 0, "completado": False, "pdf_final": ""})
+    pdf, _ = generar_remision_consolidado(df, progreso_actual, carpeta_salida)
+    progreso_actual.update({"pdf_final": pdf, "completado": True})
+
 
 def procesar_kardex():
-    threading.Thread(target=iniciar_kardex).start()
+    session_id = _get_session_id()
+    ruta_archivo = _get_uploaded_file(session_id)
+    if not ruta_archivo or not os.path.exists(ruta_archivo):
+        return jsonify({"error": "No hay un archivo cargado para procesar"}), 400
+    carpeta_salida = _get_output_dir(session_id)
+    threading.Thread(target=iniciar_kardex, args=(session_id, ruta_archivo, carpeta_salida), daemon=True).start()
     return jsonify({"status": "kardex_iniciado"})
 
+
 def procesar_remision():
-    threading.Thread(target=iniciar_remision).start()
+    session_id = _get_session_id()
+    ruta_archivo = _get_uploaded_file(session_id)
+    if not ruta_archivo or not os.path.exists(ruta_archivo):
+        return jsonify({"error": "No hay un archivo cargado para procesar"}), 400
+    carpeta_salida = _get_output_dir(session_id)
+    threading.Thread(target=iniciar_remision, args=(session_id, ruta_archivo, carpeta_salida), daemon=True).start()
     return jsonify({"status": "remision_iniciado"})
 
+
 def progreso_kardex_view():
-    return jsonify(progreso_kardex)
+    session_id = _get_session_id()
+    return jsonify(_get_progress(progreso_kardex, session_id))
+
 
 def progreso_remision_view():
-    return jsonify(progreso_remision)
+    session_id = _get_session_id()
+    return jsonify(_get_progress(progreso_remision, session_id))
+
 
 def descargar_kardex():
-    if not progreso_kardex["completado"] or not os.path.exists(progreso_kardex["pdf_final"]):
+    session_id = _get_session_id()
+    progreso_actual = _get_progress(progreso_kardex, session_id)
+    if not progreso_actual["completado"] or not os.path.exists(progreso_actual["pdf_final"]):
         return jsonify({"error": "PDF no disponible"}), 404
-    return send_file(progreso_kardex["pdf_final"], as_attachment=True)
+    return send_file(progreso_actual["pdf_final"], as_attachment=True)
+
 
 def descargar_remision():
-    if not progreso_remision["completado"] or not os.path.exists(progreso_remision["pdf_final"]):
+    session_id = _get_session_id()
+    progreso_actual = _get_progress(progreso_remision, session_id)
+    if not progreso_actual["completado"] or not os.path.exists(progreso_actual["pdf_final"]):
         return jsonify({"error": "PDF no disponible"}), 404
-    return send_file(progreso_remision["pdf_final"], as_attachment=True)
+    return send_file(progreso_actual["pdf_final"], as_attachment=True)

--- a/routes/formulario_routes.py
+++ b/routes/formulario_routes.py
@@ -4,37 +4,46 @@ from controllers.formulario_controller import (
     progreso_kardex_view, progreso_remision_view,
     descargar_kardex, descargar_remision
 )
+from utils.auth import require_auth
 
 formulario_bp = Blueprint("formulario", __name__)
 
 @formulario_bp.route("/formulario", methods=["GET"])
+@require_auth
 def formulario_view():
     return formulario()
 
 @formulario_bp.route("/formulario/cargar", methods=["POST"])
+@require_auth
 def cargar_archivo_view():
     return cargar_archivo()
 
 @formulario_bp.route("/formulario/procesar_kardex", methods=["POST"])
+@require_auth
 def procesar_kardex_view():
     return procesar_kardex()
 
 @formulario_bp.route("/formulario/procesar_remision", methods=["POST"])
+@require_auth
 def procesar_remision_view():
     return procesar_remision()
 
 @formulario_bp.route("/formulario/progreso_kardex", methods=["GET"])
+@require_auth
 def progreso_kardex_route():
     return progreso_kardex_view()
 
 @formulario_bp.route("/formulario/progreso_remision", methods=["GET"])
+@require_auth
 def progreso_remision_route():
     return progreso_remision_view()
 
 @formulario_bp.route("/formulario/descargar_kardex", methods=["GET"])
+@require_auth
 def descargar_kardex_route():
     return descargar_kardex()
 
 @formulario_bp.route("/formulario/descargar_remision", methods=["GET"])
+@require_auth
 def descargar_remision_route():
     return descargar_remision()

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,0 +1,32 @@
+import hmac
+import os
+from functools import wraps
+from flask import abort, request, session
+
+AUTH_TOKEN = os.getenv("FORM_AUTH_TOKEN")
+
+
+def _get_bearer_token():
+    header = request.headers.get("Authorization", "")
+    if header.lower().startswith("bearer "):
+        return header[7:].strip()
+    return None
+
+
+def _is_authenticated():
+    token = _get_bearer_token()
+    if token and AUTH_TOKEN and hmac.compare_digest(token, AUTH_TOKEN):
+        session["authenticated"] = True
+        return True
+    return session.get("authenticated", False)
+
+
+def require_auth(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not AUTH_TOKEN:
+            abort(500, description="La autenticación no está configurada.")
+        if not _is_authenticated():
+            abort(401, description="No autorizado: se requiere autenticación.")
+        return func(*args, **kwargs)
+    return wrapper


### PR DESCRIPTION
## Summary
- load SECRET_KEY from the environment, enforcing it in production and disabling debug mode
- add a reusable authentication decorator and protect all formulario routes
- validate uploads with allowed extensions/size, secure filenames, session-specific storage, and isolated progress tracking

## Testing
- python -m compileall app.py controllers/formulario_controller.py routes/formulario_routes.py utils/auth.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c25ac027c8322bec51db1488879ef)